### PR TITLE
Append https to themealdb.com URL

### DIFF
--- a/meal-finder/readme.md
+++ b/meal-finder/readme.md
@@ -1,6 +1,6 @@
 ## Meal Finder App
 
-Search and generate random meals from the [themealdb.com](www.themealdb.com) API
+Search and generate random meals from the [themealdb.com](https://www.themealdb.com) API
 
 ## Project Specifications
 


### PR DESCRIPTION
The mealdb URL does not work without the leading https, users are sent to a non-existent GitHub URL.