### PR TITLE
Fixed: Store Movie and Price in Local Storage

### DIFF
--- a/movie-seat-booking/script.js
+++ b/movie-seat-booking/script.js
@@ -26,6 +26,8 @@ function updateSelectedCount() {
 
   count.innerText = selectedSeatsCount;
   total.innerText = selectedSeatsCount * ticketPrice;
+  
+  setMovie(movieSelect.selectedIndex, movieSelect.value);
 }
 
 // Get data from localstorage and populate UI


### PR DESCRIPTION
If selected movie and price is not set in local storage and if i select a seat and after that if i refresh then number of seat and price shows as zero.