### PR TITLE
Fix password2 length validation

### DIFF
--- a/form-validator/script.js
+++ b/form-validator/script.js
@@ -65,6 +65,7 @@ function checkPasswordsMatch(input1, input2) {
   if (input1.value !== input2.value) {
     showError(input2, 'Passwords do not match');
   }
+  checkLength(input2, 6, 25);
 }
 
 // Get fieldname


### PR DESCRIPTION
The last commit only compared password2 with password1, it didn't validate the length of password2; this fixes the issue of password2 length validation making it independent of password1.