### PR TITLE
fix: don't show final message reveal after winning

### DIFF
--- a/hangman/script.js
+++ b/hangman/script.js
@@ -36,6 +36,7 @@ function displayWord() {
 
 	if (innerWord === selectedWord) {
 		finalMessage.innerText = 'Congratulations! You won! 😃';
+		finalMessageRevealWord.innerText = '';
 		popup.style.display = 'flex';
 
 		playable = false;


### PR DESCRIPTION
fixes #52 