### PR TITLE
path replaced with composedPath()

### DIFF
--- a/meal-finder/script.js
+++ b/meal-finder/script.js
@@ -111,7 +111,7 @@ submit.addEventListener('submit', searchMeal);
 random.addEventListener('click', getRandomMeal);
 
 mealsEl.addEventListener('click', e => {
-  const mealInfo = e.path.find(item => {
+  const mealInfo = e.composedPath().find(item => {
     if (item.classList) {
       return item.classList.contains('meal-info');
     } else {


### PR DESCRIPTION
'path' replaced with composedPath() because on Firefox browser, 'path' throws 'Uncaught TypeError: e.path is undefined'