### PR TITLE
Add hiding the nav on click outside of toggle or nav

### DIFF
--- a/modal-menu-slider/script.js
+++ b/modal-menu-slider/script.js
@@ -4,28 +4,20 @@ const open = document.getElementById('open');
 const modal = document.getElementById('modal');
 const navbar = document.getElementById('navbar');
 
-// This function closes navbar if user clicks anywhere outside of navbar once it's opened
-// Does not leave unused event listeners on
-// It's messy, but it works
-function closeNavbar(e) {
-  if (
-    document.body.classList.contains('show-nav') &&
-    e.target !== toggle &&
-    !toggle.contains(e.target) &&
-    e.target !== navbar &&
-    !navbar.contains(e.target)
-  ) {
-    document.body.classList.toggle('show-nav');
-    document.body.removeEventListener('click', closeNavbar);
-  } else if (!document.body.classList.contains('show-nav')) {
-    document.body.removeEventListener('click', closeNavbar);
-  }
-}
+// Hide nav on click outside of toggle or nav
+document.body.addEventListener('click', e => {
+  document.body.classList.contains('show-nav') &&
+  e.target != nav &&
+  !nav.contains(e.target) &&
+  e.target != toggle &&
+  !toggle.contains(e.target)
+    ? document.body.classList.toggle('show-nav')
+    : false;
+});
 
 // Toggle nav
 toggle.addEventListener('click', () => {
   document.body.classList.toggle('show-nav');
-  document.body.addEventListener('click', closeNavbar);
 });
 
 // Show modal


### PR DESCRIPTION
I have had a similar idea of missing functionality of hiding navigation on click outside of the nav in the sliding menu project as @Novailoveyou so I have made a little update and refactor to it so it fits the rest of the script - instead of writing the new function I have just added another event listener and included ternary operator similar to the last one in the code and would like to contribute my outcome.