### PR TITLE
fixed loading bug

### DIFF
--- a/infinite_scroll_blog/script.js
+++ b/infinite_scroll_blog/script.js
@@ -72,7 +72,7 @@ showPosts();
 window.addEventListener('scroll', () => {
   const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
 
-  if (scrollHeight - scrollTop === clientHeight) {
+  if (scrollHeight - scrollTop - clientHeight < 5) {
     showLoading();
   }
 });


### PR DESCRIPTION
Test in chrome(103.0.5060.114) and Edge(103.0.1264.71).
The condition is always false because they are not exactly equal.

Seems like this [commit](https://github.com/bradtraversy/vanillawebprojects/commit/15184069936ea026ff348d73698a8cac952a9e83) changed the condition.
